### PR TITLE
Fix path of generated openAPI

### DIFF
--- a/hack/openapi.sh
+++ b/hack/openapi.sh
@@ -7,4 +7,4 @@ git submodule update --init
 
 cd submodules/kubernetes
 make kube-apiserver
-cp pkg/generated/openapi/zz_generated.openapi.go "../${OPENAPIFILE}"
+cp pkg/generated/openapi/zz_generated.openapi.go "../../${OPENAPIFILE}"


### PR DESCRIPTION
Thank you for your fabulous hands-on!

### What
Fix the path of generated openAPI code in `./hack/openapi.sh`.

### Problem
When I tried to execute `make openapi`, I caught an error:
```bash
$ make openapi
./hack/openapi.sh
make[1]: Entering directory '<my_path>/mini-kube-scheduler/submodules/kubernetes'
make[2]: Entering directory '<my_path>/mini-kube-scheduler/submodules/kubernetes'
<...omit...>
make[1]: Leaving directory '<my_path>/mini-kube-scheduler/submodules/kubernetes'
cp: cannot create regular file '../k8sapiserver/openapi/zz_generated.openapi.go': No such file or directory
make: *** [Makefile:16: openapi] Error 1
```
We should specify `../../k8sapiserver/openapi/zz_...` instead of `../k8sapiserver/openapi/zz_...` because in openapi.sh, the working directory is changed to `./submodules/kubernetes`.